### PR TITLE
Add config/path arguments for commands

### DIFF
--- a/src/cli/fetch.rs
+++ b/src/cli/fetch.rs
@@ -1,18 +1,23 @@
-use std::process::ExitCode;
+use std::{path::Path, process::ExitCode};
 
 use anyhow::Result;
 use clap::Parser;
-use dalbit_core::manifest::{Manifest, WritableManifest};
+use dalbit_core::manifest::{Manifest};
 
-use super::DEFAULT_MANIFEST_PATH;
+use dalbit_core::manifest::DEFAULT_MANIFEST_PATH;
 
 /// Fetch dalbit polyfills
 #[derive(Debug, Clone, Parser)]
-pub struct FetchCommand {}
+pub struct FetchCommand {
+	/// Path to the manifest file
+    #[arg(long, default_value = DEFAULT_MANIFEST_PATH)]
+    config: String,
+}
 
 impl FetchCommand {
     pub async fn run(self) -> Result<ExitCode> {
-        let manifest = Manifest::from_file(DEFAULT_MANIFEST_PATH).await?;
+		let config_path = Path::new(&self.config);
+        let manifest = Manifest::from_file(config_path).await?;
         let polyfill_cache = manifest.polyfill().cache().await?;
         polyfill_cache.fetch()?;
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,25 +1,36 @@
-use std::{path::Path, process::ExitCode};
+use std::{path::{Path, PathBuf}, process::ExitCode};
 
 use anyhow::{anyhow, Result};
 use clap::Parser;
-use dalbit_core::manifest::{Manifest, WritableManifest};
+use dalbit_core::manifest::Manifest;
 
-use crate::cli::DEFAULT_MANIFEST_PATH;
+use dalbit_core::manifest::DEFAULT_MANIFEST_PATH;
 
 /// Initialize dalbit manifest file
 #[derive(Debug, Clone, Parser)]
-pub struct InitCommand {}
+pub struct InitCommand {
+    /// Path to initialize the manifest file
+    path: Option<String>,
+}
 
 impl InitCommand {
     pub async fn run(self) -> Result<ExitCode> {
-        if Path::new(DEFAULT_MANIFEST_PATH).exists() {
+        let mut buffer = PathBuf::new();
+        let config_path = self.path
+            .as_deref()
+            .map(|p| {
+                buffer = Path::new(p).join("dalbit.toml");
+                buffer.as_path()
+            })
+            .unwrap_or_else(|| Path::new(DEFAULT_MANIFEST_PATH));
+        log::debug!("config path: {:?}", config_path);
+        if config_path.exists() {
             return Err(anyhow!("Manifest has already been initialized"));
-        } else {
-            let manifest = Manifest::default();
-            manifest.write(DEFAULT_MANIFEST_PATH).await?;
-
-            println!("Initialized dalbit manifest");
         }
+        let manifest = Manifest::default();
+        manifest.write(config_path).await?;
+
+        println!("Initialized dalbit manifest");
 
         return Ok(ExitCode::SUCCESS);
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,8 +14,6 @@ use init::InitCommand;
 use log::LevelFilter;
 use transpile::TranspileCommand;
 
-pub const DEFAULT_MANIFEST_PATH: &str = "dalbit.toml";
-
 #[derive(Debug, Clone, Subcommand)]
 pub enum CliSubcommand {
     Transpile(TranspileCommand),

--- a/src/cli/transpile.rs
+++ b/src/cli/transpile.rs
@@ -1,24 +1,26 @@
-use std::process::ExitCode;
+use std::{path::Path, process::ExitCode};
 
 use anyhow::Result;
 use clap::Parser;
-use dalbit_core::{
-    manifest::{Manifest, WritableManifest},
-    transpile,
-};
+use dalbit_core::{manifest::Manifest, transpile};
 use std::time::Instant;
 
-use super::DEFAULT_MANIFEST_PATH;
+use dalbit_core::manifest::DEFAULT_MANIFEST_PATH;
 
 /// Transpile luau files into lua files
 #[derive(Debug, Clone, Parser)]
-pub struct TranspileCommand {}
+pub struct TranspileCommand {
+    /// Path to the manifest file
+    #[arg(long, default_value = DEFAULT_MANIFEST_PATH)]
+    config: String,
+}
 
 impl TranspileCommand {
     pub async fn run(self) -> Result<ExitCode> {
+        let config_path = Path::new(&self.config);
         let process_start_time = Instant::now();
 
-        let manifest = Manifest::from_file(DEFAULT_MANIFEST_PATH).await?;
+        let manifest = Manifest::from_file(config_path).await?;
 
         transpile::process(manifest).await?;
 

--- a/src/lib/manifest.rs
+++ b/src/lib/manifest.rs
@@ -1,27 +1,12 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use indexmap::IndexMap;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use tokio::fs;
 
 use crate::{polyfill::Polyfill, TargetVersion};
 
-#[async_trait::async_trait]
-pub trait WritableManifest: Send + Sized + Serialize + DeserializeOwned {
-    #[inline]
-    async fn from_file(path: impl Into<PathBuf> + Send) -> Result<Self> {
-        let content = fs::read_to_string(path.into()).await?;
-
-        Ok(toml::from_str(content.as_str())?)
-    }
-
-    #[inline]
-    async fn write(&self, path: impl Into<PathBuf> + Send) -> Result<()> {
-        fs::write(path.into(), toml::to_string(self)?).await?;
-
-        Ok(())
-    }
-}
+pub const DEFAULT_MANIFEST_PATH: &str = "dalbit.toml";
 
 /// Manifest for dalbit transpiler. This is a writable manifest.
 #[derive(Debug, Deserialize, Serialize)]
@@ -33,6 +18,8 @@ pub struct Manifest {
     pub minify: bool,
     modifiers: IndexMap<String, bool>,
     polyfill: Polyfill,
+    #[serde(skip)]
+    path: PathBuf,
 }
 
 impl Default for Manifest {
@@ -45,21 +32,40 @@ impl Default for Manifest {
             minify: true,
             modifiers: IndexMap::new(),
             polyfill: Polyfill::default(),
+            path: Path::new(DEFAULT_MANIFEST_PATH).to_owned(),
         }
     }
 }
 
-impl WritableManifest for Manifest {}
-
 impl Manifest {
-    #[inline]
-    pub fn input(&self) -> &PathBuf {
-        &self.input
+    /// Load manifest from file.
+    pub async fn from_file(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        let manifest = fs::read_to_string(&path).await?;
+        let mut manifest: Manifest = toml::from_str(&manifest)
+            .with_context(|| format!("Failed to parse manifest file: {:?}", path))?;
+        manifest.path = path;
+        Ok(manifest)
+    }
+
+    /// Write manifest to file.
+    pub async fn write(&self, path: impl Into<PathBuf>) -> Result<()> {
+        fs::write(path.into(), toml::to_string(self)?).await?;
+        Ok(())
     }
 
     #[inline]
-    pub fn output(&self) -> &PathBuf {
-        &self.output
+    pub fn input(&self) -> PathBuf {
+        let path = self.path.parent().unwrap().join(&self.input);
+        log::debug!("manifest input path: {:?}", path);
+        path
+    }
+
+    #[inline]
+    pub fn output(&self) -> PathBuf {
+        let path = self.path.parent().unwrap().join(&self.output);
+        log::debug!("manifest output path: {:?}", path);
+        path
     }
 
     #[inline]

--- a/src/lib/polyfill.rs
+++ b/src/lib/polyfill.rs
@@ -14,7 +14,6 @@ use std::str::FromStr;
 use tokio::fs;
 use url::Url;
 
-use crate::manifest::WritableManifest;
 use crate::{utils, TargetVersion};
 
 pub const DEFAULT_REPO_URL: &str = "https://github.com/CavefulGames/dalbit-polyfill";
@@ -111,7 +110,22 @@ pub struct PolyfillManifest {
     lua_version: TargetVersion,
 }
 
-impl WritableManifest for PolyfillManifest {}
+impl PolyfillManifest {
+    /// Load polyfill manifest from file.
+    pub async fn from_file(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        let manifest = fs::read_to_string(&path).await?;
+        let manifest: Self = toml::from_str(&manifest)
+            .with_context(|| format!("Could not parse polyfill manifest file: {:?}", path))?;
+        Ok(manifest)
+    }
+
+    /// Write polyfill manifest to file.
+    pub async fn write(&self, path: impl Into<PathBuf>) -> Result<()> {
+        fs::write(path.into(), toml::to_string(self)?).await?;
+        Ok(())
+    }
+}
 
 /// Polyfill's globals.
 #[derive(Debug)]

--- a/src/lib/transpile.rs
+++ b/src/lib/transpile.rs
@@ -156,8 +156,14 @@ async fn private_process(
 }
 
 pub async fn process(manifest: Manifest) -> Result<()> {
-    let output_files =
-        private_process(&manifest, manifest.input(), manifest.output(), None, false).await?;
+    let output_files = private_process(
+        &manifest,
+        &manifest.input(),
+        &manifest.output(),
+        None,
+        false,
+    )
+    .await?;
     let polyfill = manifest.polyfill();
     let polyfill_cache = polyfill.cache().await?;
     let polyfill_config = polyfill_cache.config();


### PR DESCRIPTION
You can now specify the config path with commands(`fetch`, `transpile`)

also you can specify the path to initialize with `dalbit init` now

`WritableManifest` trait was removed in favor of storing path in Manifest from `Manifest::from_file()`