### PR TITLE
Support pesde tooling

### DIFF
--- a/.d.luau
+++ b/.d.luau
@@ -1,0 +1,3 @@
+declare _G: {
+	PESDE_ROOT: string?,
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 playground
 
+luau_packages
+lune_packages
 
 # Added by cargo
 

--- a/.luaurc
+++ b/.luaurc
@@ -1,0 +1,6 @@
+{
+  "aliases": {
+    "lune": "~/.lune/.typedefs/0.8.9/"
+  },
+  "languageMode": "strict"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+	"luau-lsp.types.definitionFiles": [
+		".d.luau"
+	]
+}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Dalbit(달빛) is a Luau-to-Lua transpiler, designed specifically for `Lua 5.3`.
 
 ## Installation
 
-### [Via pesde](https://pesde.dev/packages/caveful_games/dalbit)
+### Using [pesde](https://pesde.dev/packages/caveful_games/dalbit)
 ```sh
 pesde add caveful_games/dalbit --dev --target lune
 ```

--- a/README.md
+++ b/README.md
@@ -20,9 +20,14 @@ Dalbit(달빛) is a Luau-to-Lua transpiler, designed specifically for `Lua 5.3`.
 ## Installation
 
 ### Using [pesde](https://pesde.dev/packages/caveful_games/dalbit)
+To manage/install with pesde manifest:
 ```sh
 pesde add caveful_games/dalbit --dev --target lune
 pesde install
+```
+To run directly from anywhere:
+```sh
+pesde x caveful_games/dalbit
 ```
 
 ### [From Releases](https://github.com/CavefulGames/dalbit/releases)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Dalbit(달빛) is a Luau-to-Lua transpiler, designed specifically for `Lua 5.3`.
 ### Using [pesde](https://pesde.dev/packages/caveful_games/dalbit)
 ```sh
 pesde add caveful_games/dalbit --dev --target lune
+pesde install
 ```
 
 ### [From Releases](https://github.com/CavefulGames/dalbit/releases)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Dalbit(달빛) is a Luau-to-Lua transpiler, designed specifically for `Lua 5.3`.
 
 ## Installation
 
+### [Via pesde](https://pesde.dev/packages/caveful_games/dalbit)
+```sh
+pesde add caveful_games/dalbit --dev --target lune
+```
+
 ### [From Releases](https://github.com/CavefulGames/dalbit/releases)
 
 ### Using Cargo (build from source)

--- a/bin.luau
+++ b/bin.luau
@@ -1,0 +1,1 @@
+require("./lune_packages/toolchainlib")("CavefulGames/dalbit", _G.PESDE_ROOT)

--- a/pesde.lock
+++ b/pesde.lock
@@ -1,0 +1,264 @@
+name = "caveful_games/dalbit"
+version = "0.1.1"
+target = "lune"
+
+[graph."0x5eal/unzip@0.1.3 luau"]
+resolved_ty = "standard"
+
+[graph."0x5eal/unzip@0.1.3 luau".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/pesde-pkg/index"
+
+[graph."0x5eal/unzip@0.1.3 luau".pkg_ref.dependencies]
+asciitable = [{ name = "kimpure/asciitable", version = "^0.2.1", index = "https://github.com/pesde-pkg/index" }, "dev"]
+frktest = [{ name = "itsfrank/frktest", version = "^0.0.2", index = "https://github.com/pesde-pkg/index", target = "lune" }, "dev"]
+luau-lsp = [{ name = "pesde/luau_lsp", version = "=1.39.2", index = "https://github.com/pesde-pkg/index", target = "lune" }, "dev"]
+stylua = [{ name = "pesde/stylua", version = "=2.0.2", index = "https://github.com/pesde-pkg/index", target = "lune" }, "dev"]
+
+[graph."corecii/greentea@0.4.11 lune"]
+resolved_ty = "standard"
+
+[graph."corecii/greentea@0.4.11 lune".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/daimond113/pesde-index"
+
+[graph."jiwonz/dirs@0.3.0 lune"]
+resolved_ty = "standard"
+
+[graph."jiwonz/dirs@0.3.0 lune".dependencies]
+"corecii/greentea@0.4.11 lune" = "greentea"
+"jiwonz/pathfs@0.3.2 lune" = "pathfs"
+
+[graph."jiwonz/dirs@0.3.0 lune".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/pesde-pkg/index"
+
+[graph."jiwonz/dirs@0.3.0 lune".pkg_ref.dependencies]
+greentea = [{ name = "corecii/greentea", version = "^0.4.10", index = "https://github.com/daimond113/pesde-index" }, "standard"]
+luau_lsp = [{ name = "pesde/luau_lsp", version = "^1.38.1", index = "https://github.com/daimond113/pesde-index" }, "dev"]
+pathfs = [{ name = "jiwonz/pathfs", version = "^0.3.0", index = "https://github.com/daimond113/pesde-index" }, "standard"]
+selene = [{ name = "pesde/selene", version = "^0.28.0", index = "https://github.com/daimond113/pesde-index" }, "dev"]
+stylua = [{ name = "pesde/stylua", version = "^2.0.2", index = "https://github.com/daimond113/pesde-index" }, "dev"]
+
+[graph."jiwonz/dirs@0.4.0 lune"]
+resolved_ty = "standard"
+
+[graph."jiwonz/dirs@0.4.0 lune".dependencies]
+"corecii/greentea@0.4.11 lune" = "greentea"
+"jiwonz/pathfs@0.6.0-rc.2 lune" = "pathfs"
+
+[graph."jiwonz/dirs@0.4.0 lune".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/pesde-pkg/index"
+
+[graph."jiwonz/dirs@0.4.0 lune".pkg_ref.dependencies]
+greentea = [{ name = "corecii/greentea", version = "^0.4.10", index = "https://github.com/daimond113/pesde-index" }, "standard"]
+luau_check = [{ name = "jiwonz/luau_check", version = "^0.3.8", index = "https://github.com/daimond113/pesde-index" }, "dev"]
+pathfs = [{ name = "jiwonz/pathfs", version = "^0.6.0-rc.1", index = "https://github.com/daimond113/pesde-index" }, "standard"]
+
+[graph."jiwonz/luau_check@0.3.11 lune"]
+direct = ["luau_check", { name = "jiwonz/luau_check", version = "^0.3.11", index = "default" }, "dev"]
+resolved_ty = "dev"
+
+[graph."jiwonz/luau_check@0.3.11 lune".dependencies]
+"jiwonz/dirs@0.4.0 lune" = "dirs"
+"jiwonz/pathfs@0.6.0-rc.2 lune" = "pathfs"
+"jiwonz/pesde_exec@0.4.2 lune" = "pesde_exec"
+"pesde/luau_lsp@1.40.0 lune" = "luau_lsp"
+"pesde/selene@0.28.0 lune" = "selene"
+"pesde/stylua@2.0.2 lune" = "stylua"
+
+[graph."jiwonz/luau_check@0.3.11 lune".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/pesde-pkg/index"
+
+[graph."jiwonz/luau_check@0.3.11 lune".pkg_ref.dependencies]
+dirs = [{ name = "jiwonz/dirs", version = "^0.4.0", index = "https://github.com/pesde-pkg/index" }, "standard"]
+luau_lsp = [{ name = "pesde/luau_lsp", version = "^1.39.2", index = "https://github.com/pesde-pkg/index" }, "peer"]
+pathfs = [{ name = "jiwonz/pathfs", version = "^0.6.0-rc.2", index = "https://github.com/pesde-pkg/index" }, "standard"]
+pesde_exec = [{ name = "jiwonz/pesde_exec", version = "^0.4.2", index = "https://github.com/pesde-pkg/index" }, "standard"]
+selene = [{ name = "pesde/selene", version = "^0.28.0", index = "https://github.com/pesde-pkg/index" }, "peer"]
+stylua = [{ name = "pesde/stylua", version = "^2.0.2", index = "https://github.com/pesde-pkg/index" }, "peer"]
+
+[graph."jiwonz/luau_disk@0.1.4 luau"]
+resolved_ty = "standard"
+
+[graph."jiwonz/luau_disk@0.1.4 luau".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/pesde-pkg/index"
+
+[graph."jiwonz/luau_path@0.1.1 luau"]
+resolved_ty = "standard"
+
+[graph."jiwonz/luau_path@0.1.1 luau".dependencies]
+"jiwonz/luau_disk@0.1.4 luau" = "luau_disk"
+
+[graph."jiwonz/luau_path@0.1.1 luau".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/daimond113/pesde-index"
+
+[graph."jiwonz/luau_path@0.1.1 luau".pkg_ref.dependencies]
+luau_disk = [{ name = "jiwonz/luau_disk", version = "^0.1.2", index = "https://github.com/pesde-pkg/index" }, "standard"]
+
+[graph."jiwonz/pathfs@0.3.2 lune"]
+resolved_ty = "standard"
+
+[graph."jiwonz/pathfs@0.3.2 lune".dependencies]
+"corecii/greentea@0.4.11 lune" = "greentea"
+"jiwonz/luau_path@0.1.1 luau" = "luau_path"
+
+[graph."jiwonz/pathfs@0.3.2 lune".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/pesde-pkg/index"
+
+[graph."jiwonz/pathfs@0.3.2 lune".pkg_ref.dependencies]
+frktest = [{ name = "itsfrank/frktest", version = "^0.0.2", index = "https://github.com/daimond113/pesde-index" }, "dev"]
+greentea = [{ name = "corecii/greentea", version = "^0.4.11", index = "https://github.com/daimond113/pesde-index" }, "standard"]
+luau_check = [{ name = "jiwonz/luau_check", version = "^0.3.8", index = "https://github.com/daimond113/pesde-index" }, "dev"]
+luau_path = [{ name = "jiwonz/luau_path", version = "^0.1.1", index = "https://github.com/daimond113/pesde-index", target = "luau" }, "standard"]
+
+[graph."jiwonz/pathfs@0.5.2 lune"]
+resolved_ty = "standard"
+
+[graph."jiwonz/pathfs@0.5.2 lune".dependencies]
+"corecii/greentea@0.4.11 lune" = "greentea"
+"jiwonz/luau_path@0.1.1 luau" = "luau_path"
+
+[graph."jiwonz/pathfs@0.5.2 lune".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/pesde-pkg/index"
+
+[graph."jiwonz/pathfs@0.5.2 lune".pkg_ref.dependencies]
+frktest = [{ name = "itsfrank/frktest", version = "^0.0.2", index = "https://github.com/daimond113/pesde-index" }, "dev"]
+greentea = [{ name = "corecii/greentea", version = "^0.4.11", index = "https://github.com/daimond113/pesde-index" }, "standard"]
+luau_lsp = [{ name = "pesde/luau_lsp", version = "^1.38.1", index = "https://github.com/daimond113/pesde-index" }, "dev"]
+luau_path = [{ name = "jiwonz/luau_path", version = "^0.1.1", index = "https://github.com/daimond113/pesde-index", target = "luau" }, "standard"]
+selene = [{ name = "pesde/selene", version = "^0.28.0", index = "https://github.com/daimond113/pesde-index" }, "dev"]
+stylua = [{ name = "pesde/stylua", version = "^2.0.2", index = "https://github.com/daimond113/pesde-index" }, "dev"]
+
+[graph."jiwonz/pathfs@0.6.0-rc.2 lune"]
+resolved_ty = "standard"
+
+[graph."jiwonz/pathfs@0.6.0-rc.2 lune".dependencies]
+"corecii/greentea@0.4.11 lune" = "greentea"
+"jiwonz/luau_path@0.1.1 luau" = "luau_path"
+
+[graph."jiwonz/pathfs@0.6.0-rc.2 lune".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/pesde-pkg/index"
+
+[graph."jiwonz/pathfs@0.6.0-rc.2 lune".pkg_ref.dependencies]
+frktest = [{ name = "itsfrank/frktest", version = "^0.0.2", index = "https://github.com/daimond113/pesde-index" }, "dev"]
+greentea = [{ name = "corecii/greentea", version = "^0.4.11", index = "https://github.com/daimond113/pesde-index" }, "standard"]
+luau_check = [{ name = "jiwonz/luau_check", version = "^0.3.8", index = "https://github.com/daimond113/pesde-index" }, "dev"]
+luau_path = [{ name = "jiwonz/luau_path", version = "^0.1.1", index = "https://github.com/daimond113/pesde-index", target = "luau" }, "standard"]
+
+[graph."jiwonz/pesde_exec@0.4.2 lune"]
+resolved_ty = "standard"
+
+[graph."jiwonz/pesde_exec@0.4.2 lune".dependencies]
+"corecii/greentea@0.4.11 lune" = "greentea"
+"jiwonz/pathfs@0.5.2 lune" = "pathfs"
+
+[graph."jiwonz/pesde_exec@0.4.2 lune".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/pesde-pkg/index"
+
+[graph."jiwonz/pesde_exec@0.4.2 lune".pkg_ref.dependencies]
+greentea = [{ name = "corecii/greentea", version = "^0.4.11", index = "https://github.com/pesde-pkg/index" }, "standard"]
+luau_lsp = [{ name = "pesde/luau_lsp", version = "^1.38.1", index = "https://github.com/pesde-pkg/index" }, "dev"]
+pathfs = [{ name = "jiwonz/pathfs", version = "^0.5.2", index = "https://github.com/pesde-pkg/index" }, "standard"]
+selene = [{ name = "pesde/selene", version = "^0.28.0", index = "https://github.com/pesde-pkg/index" }, "dev"]
+stylua = [{ name = "pesde/stylua", version = "^2.0.2", index = "https://github.com/pesde-pkg/index" }, "dev"]
+
+[graph."lukadev_0/option@1.2.0 lune"]
+direct = ["option", { name = "lukadev_0/option", version = "^1.2.0", index = "default" }, "standard"]
+resolved_ty = "standard"
+
+[graph."lukadev_0/option@1.2.0 lune".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/pesde-pkg/index"
+
+[graph."lukadev_0/result@1.2.0 lune"]
+direct = ["result", { name = "lukadev_0/result", version = "^1.2.0", index = "default" }, "standard"]
+resolved_ty = "standard"
+
+[graph."lukadev_0/result@1.2.0 lune".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/pesde-pkg/index"
+
+[graph."pesde/luau_lsp@1.40.0 lune"]
+resolved_ty = "peer"
+is_peer = true
+
+[graph."pesde/luau_lsp@1.40.0 lune".dependencies]
+"lukadev_0/option@1.2.0 lune" = "option"
+"lukadev_0/result@1.2.0 lune" = "result"
+"pesde/toolchainlib@0.1.12 lune" = "core"
+
+[graph."pesde/luau_lsp@1.40.0 lune".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/pesde-pkg/index"
+
+[graph."pesde/luau_lsp@1.40.0 lune".pkg_ref.dependencies]
+core = [{ name = "pesde/toolchainlib", version = "^0.1.12", index = "https://github.com/pesde-pkg/index", target = "lune" }, "standard"]
+option = [{ name = "lukadev_0/option", version = "^1.2.0", index = "https://github.com/pesde-pkg/index" }, "standard"]
+result = [{ name = "lukadev_0/result", version = "^1.2.0", index = "https://github.com/pesde-pkg/index" }, "standard"]
+
+[graph."pesde/selene@0.28.0 lune"]
+resolved_ty = "peer"
+is_peer = true
+
+[graph."pesde/selene@0.28.0 lune".dependencies]
+"lukadev_0/option@1.2.0 lune" = "option"
+"lukadev_0/result@1.2.0 lune" = "result"
+"pesde/toolchainlib@0.1.12 lune" = "core"
+
+[graph."pesde/selene@0.28.0 lune".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/pesde-pkg/index"
+
+[graph."pesde/selene@0.28.0 lune".pkg_ref.dependencies]
+core = [{ name = "pesde/toolchainlib", version = "^0.1.8", index = "https://github.com/daimond113/pesde-index", target = "lune" }, "standard"]
+option = [{ name = "lukadev_0/option", version = "^1.2.0", index = "https://github.com/daimond113/pesde-index" }, "standard"]
+result = [{ name = "lukadev_0/result", version = "^1.2.0", index = "https://github.com/daimond113/pesde-index" }, "standard"]
+
+[graph."pesde/stylua@2.0.2 lune"]
+resolved_ty = "peer"
+is_peer = true
+
+[graph."pesde/stylua@2.0.2 lune".dependencies]
+"lukadev_0/option@1.2.0 lune" = "option"
+"lukadev_0/result@1.2.0 lune" = "result"
+"pesde/toolchainlib@0.1.12 lune" = "core"
+
+[graph."pesde/stylua@2.0.2 lune".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/pesde-pkg/index"
+
+[graph."pesde/stylua@2.0.2 lune".pkg_ref.dependencies]
+core = [{ name = "pesde/toolchainlib", version = "^0.1.3", index = "https://github.com/daimond113/pesde-index", target = "lune" }, "standard"]
+option = [{ name = "lukadev_0/option", version = "^1.2.0", index = "https://github.com/daimond113/pesde-index" }, "standard"]
+result = [{ name = "lukadev_0/result", version = "^1.2.0", index = "https://github.com/daimond113/pesde-index" }, "standard"]
+
+[graph."pesde/toolchainlib@0.1.12 lune"]
+direct = ["toolchainlib", { name = "pesde/toolchainlib", version = "^0.1.12", index = "default" }, "standard"]
+resolved_ty = "standard"
+
+[graph."pesde/toolchainlib@0.1.12 lune".dependencies]
+"0x5eal/unzip@0.1.3 luau" = "unzip"
+"jiwonz/dirs@0.3.0 lune" = "dirs"
+"jiwonz/pathfs@0.3.2 lune" = "pathfs"
+"lukadev_0/option@1.2.0 lune" = "option"
+"lukadev_0/result@1.2.0 lune" = "result"
+
+[graph."pesde/toolchainlib@0.1.12 lune".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/pesde-pkg/index"
+
+[graph."pesde/toolchainlib@0.1.12 lune".pkg_ref.dependencies]
+dirs = [{ name = "jiwonz/dirs", version = "^0.3.0", index = "https://github.com/pesde-pkg/index" }, "standard"]
+option = [{ name = "lukadev_0/option", version = "^1.2.0", index = "https://github.com/pesde-pkg/index" }, "peer"]
+pathfs = [{ name = "jiwonz/pathfs", version = "^0.3.0", index = "https://github.com/pesde-pkg/index" }, "standard"]
+result = [{ name = "lukadev_0/result", version = "^1.2.0", index = "https://github.com/pesde-pkg/index" }, "peer"]
+unzip = [{ name = "0x5eal/unzip", version = "^0.1.0", index = "https://github.com/pesde-pkg/index", target = "luau" }, "standard"]

--- a/pesde.toml
+++ b/pesde.toml
@@ -1,0 +1,26 @@
+name = "caveful_games/dalbit"
+version = "0.1.1"
+description = "A Luau-to-Lua transpiler"
+authors = ["jiwonz <me@jiwonz.kr>"]
+repository = "https://github.com/CavefulGames/dalbit"
+license = "MIT"
+includes = ["README.md", "LICENSE.md", "bin.luau", "pesde.toml"]
+
+[target]
+environment = "lune"
+bin = "bin.luau"
+
+[indices]
+default = "https://github.com/pesde-pkg/index"
+
+[engines]
+lune = "^0.8.9"
+pesde = "^0.6.0"
+
+[dependencies]
+result = { name = "lukadev_0/result", version = "^1.2.0" }
+option = { name = "lukadev_0/option", version = "^1.2.0" }
+toolchainlib = { name = "pesde/toolchainlib", version = "^0.1.12" }
+
+[dev_dependencies]
+luau_check = { name = "jiwonz/luau_check", version = "^0.3.11" }

--- a/selene.toml
+++ b/selene.toml
@@ -1,0 +1,4 @@
+std = "luau"
+
+[config.global_usage]
+ignore_pattern = "PESDE_ROOT"


### PR DESCRIPTION
Supports pesde tooling using [`pesde/toolchainlib`](https://github.com/pesde-pkg/tooling/tree/main/toolchainlib)

The package will be published/maintained by Caveful Games

(`caveful_games/dalbit@0.1.1` was published in pesde already from this branch)